### PR TITLE
modified to work with cartesian grids

### DIFF
--- a/pycnal/pycnal/grid.py
+++ b/pycnal/pycnal/grid.py
@@ -297,6 +297,12 @@ def get_ROMS_hgrid(gridid):
                      x_psi=x_psi, y_psi=y_psi, dx=dx, dy=dy, \
                      dndx=dndx, dmde=dmde, angle_rho=angle)
 
+        #load the mask
+        try:
+          hgrd.mask_rho = np.array(nc.variables['mask_rho'][:])
+        except:
+          hgrd.mask_rho = np.ones(hgrd.y_rho.shape)
+
     else:
         #geographical grid
         print('Load geographical grid from file')
@@ -366,11 +372,11 @@ def get_ROMS_hgrid(gridid):
                          lon_psi=lon_psi, lat_psi=lat_psi, dx=dx, dy=dy, \
                          dndx=dndx, dmde=dmde, angle_rho=angle)
 
-    #load the mask
-    try:
-        hgrd.mask_rho = np.array(nc.variables['mask_rho'][:])
-    except:
-        hgrd.mask_rho = np.ones(hgrd.lat_rho.shape)
+        #load the mask
+        try:
+          hgrd.mask_rho = np.array(nc.variables['mask_rho'][:])
+        except:
+          hgrd.mask_rho = np.ones(hgrd.lat_rho.shape)
 
     return hgrd
 


### PR DESCRIPTION
The code assumed, when trying to create a mask that was missing in the history file, that the ROMS was run in spherical mode. 
Modified code so it also works with a Cartesian grid.